### PR TITLE
Added game headlines to display.

### DIFF
--- a/src/components/FeaturedGame/index.js
+++ b/src/components/FeaturedGame/index.js
@@ -7,7 +7,7 @@ import { useEffect, useState, useRef } from 'react'
  * Internal Dependencies
  */
 import ESPN from 'images/ESPN_wordmark.svg'
-import { useAsync } from 'utils/utils'
+import { useAsync, shortenConferenceName } from 'utils/utils'
 import { getGameTime, gameShouldHaveStarted, getLiveGameData } from 'utils/game'
 import { PrettyGameInfo, ScrolledOverflowContainer } from './style'
 
@@ -19,12 +19,25 @@ const TeamGameLogo = ({team}) => {
     )
 }
 
+const GameHeadline = ( { gameNotes, className = '' } ) => {
+    if ( ! gameNotes ) {
+        return '';
+    }
+
+    return (
+        <div className={`game-headline ${ className }`}>
+            <p>{ shortenConferenceName( gameNotes[0].headline ) }</p>
+        </div>
+    )
+}
+
 const FutureGame = ( {gameData} ) => {
     const {mediaDisplayName, homeTeam, awayTeam, venue, gamecastLink, gameTimeData} = gameData
 
     return(
         <div className="next-game">
-            <PrettyGameInfo className="prettyGameInfo future-game">
+            <PrettyGameInfo className={ `prettyGameInfo future-game ${ gameData?.notes?.length > 0 && gameData.notes[0].headline ? 'has-headline' : '' }` }>
+                <GameHeadline gameNotes={ gameData?.notes } />
                 <div className="away">
                     <span className="team-name"><span className="rank">{awayTeam.rank}</span> {awayTeam.team.displayName}</span>
                     <TeamGameLogo team={awayTeam} />
@@ -33,6 +46,7 @@ const FutureGame = ( {gameData} ) => {
                     <span className="channel">{mediaDisplayName ? mediaDisplayName : ''}</span>
                     <span className="date">{gameTimeData.dayMonth}</span>
                     <span className="time">{gameTimeData.time}</span>
+                    <span className="headline"><GameHeadline gameNotes={ gameData?.notes } className="in-gdtc" /></span>
                 </div>
                 <div className="home">
                     <span className="team-name"><span className="rank">{homeTeam.rank}</span>{homeTeam.team.displayName}</span>
@@ -86,6 +100,7 @@ const CurrentGame = ( { gameData, basicGameData } ) => {
     return(
         <div className="next-game">
             <PrettyGameInfo className={`prettyGameInfo in-progress-game${someoneHasPossession ? ' possession' : ''}`}>
+                <GameHeadline gameNotes={ gameData?.notes } />
                 <div className={`away${awayTeam.possession ? ' has-possession' : ''}`}>
                     <span className="team-name"><span className="rank">{awayTeam.rank}</span> {awayTeam.team.displayName}</span>
                     <TeamGameLogo team={awayTeam} />

--- a/src/components/FeaturedGame/style.js
+++ b/src/components/FeaturedGame/style.js
@@ -9,6 +9,39 @@ export const PrettyGameInfo = styled.div`
     padding: 1em 1em .5em;
     border-radius: 10px;
 
+    &.has-headline {
+        grid-template-rows: max-content 1fr;
+        padding: 0 0 .5em;
+
+        .game-headline {
+
+            &:not(.in-gdtc) {
+                grid-column: 1/-1;
+                margin: 0 0 15px;
+                padding: 10px 1.5em;
+                background: #fafafa;
+                border-top: 1px solid #f1f2f3;
+                border-bottom: 1px solid #f1f2f3;
+                border-radius: 10px 10px 0 0;
+
+                @media screen and ( max-width: 550px ) {
+                    display: none;
+                }
+
+                p {
+                    text-align: center;
+                    color: #6c6d6f;
+                    font-size: 12px;
+                }
+            }
+
+            p {
+                margin: 0;
+                letter-spacing: 1px;
+            }
+        }
+    }
+
     &.in-progress-game {
 
         .away {
@@ -220,11 +253,11 @@ export const PrettyGameInfo = styled.div`
             grid-template-rows: 1fr;
             grid-template-columns: max-content max-content 1fr;
             grid-column-gap: 8px;
-            margin: 0 0 15px;
             align-items: center;
             grid-column-start: 1;
             grid-column-end: 4;
             grid-row-start: 1;
+            margin: 0 0 15px;
             padding: 10px 1.5em;
             background: #fafafa;
             border-top: 1px solid #f1f2f3;
@@ -263,6 +296,31 @@ export const PrettyGameInfo = styled.div`
             @media screen and (max-width: 550px) {
                 grid-column-start: 2;
                 grid-row-start: 1;
+            }
+        }
+    }
+
+    &.has-headline {
+        .game-date-time-channel {
+            .headline {
+                display: none;
+            }
+            @media screen and (max-width: 550px) {
+                grid-template-columns: max-content 1fr max-content max-content;
+
+                .channel {
+                    grid-column-start: 4;
+                }
+
+                .time {
+                    grid-column-start: 3;
+                }
+
+                .headline {
+                    display: block;
+                    grid-row-start: 1;
+                    grid-column-start: 2;
+                }
             }
         }
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -300,6 +300,40 @@ const slugifyText = (text) => {
     return text.replace(/\s+/g, '-').toLowerCase()
 }
 
+const shortenConferenceName = ( text ) => {
+    const conferences = [
+        { name: "Atlantic Coast Conference", shortName: "ACC" },
+        { name: "American Athletic Conference", shortName: "AAC" },
+        { name: "Big 12", shortName: "Big 12" },
+        { name: "Big Ten", shortName: "B10" },
+        { name: "Conference USA", shortName: "C-USA" },
+        { name: "Mid-American Conference", shortName: "MAC" },
+        { name: "Mountain West Conference", shortName: "Mountain West" },
+        { name: "Pac-12", shortName: "Pac-12" },
+        { name: "Southeastern Conference", shortName: "SEC" },
+        { name: "Sun Belt", shortName: "Sun Belt" },
+    ];
+
+    const conferenceToReplace = conferences.filter( conference => {
+        const nameToCheck = conference.name.toLowerCase();
+        const stringToCheck = text.toLowerCase();
+        return stringToCheck.includes( nameToCheck );
+    });
+    
+    const conference = conferenceToReplace[0];
+    
+    // replace as-is
+    text = text.replace( conference.name, conference.shortName )
+    
+    // replace uppercase
+    text = text.replace( conference.name.toUpperCase(), conference.shortName.toUpperCase() )
+
+    // replace lowercase
+    text = text.replace( conference.name.toLowerCase(), conference.shortName.toLowerCase() )
+
+    return text;
+}
+
 function useSafeDispatch(dispatch) {
     const mounted = React.useRef(false)
     React.useLayoutEffect(() => {
@@ -377,4 +411,4 @@ function useAsync(initialState) {
   }
 }
 
-export {getUser, getAllUsers, sortUsersByPoints, getLeague, getAllTeamData, getTeamData, getUserDisplayName, getTeamRecord, getTeamWins, useLocalStorage, getTotalRosterPoints, getUserLeagueRoster, getRankString, getRankedLeagueUsers, slugifyText, useAsync, dateToESPNISO}
+export {getUser, getAllUsers, sortUsersByPoints, getLeague, getAllTeamData, getTeamData, getUserDisplayName, getTeamRecord, getTeamWins, useLocalStorage, getTotalRosterPoints, getUserLeagueRoster, getRankString, getRankedLeagueUsers, slugifyText, shortenConferenceName, useAsync, dateToESPNISO}


### PR DESCRIPTION
If a game has a "headline" in the notes, it's likely a conference championship game or a bowl game. Let's display that.

I've also introduced a function to convert a long-form version of the conference name that appears in the headlines to a shorter version because, really, who wants to read out "American Athletic Conference Championship Game?"